### PR TITLE
Update actor list styles in actors and article layouts

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -42,16 +42,18 @@
             <h2>
               出演者
             </h2>
-            <div class="article-actors">
+            <ul class="actor-links">
               {% for actor_id in page.actor_ids %}
                 {% assign actor = site.actors | where:"actor_id", actor_id | first %}
-                <a href="{{ actor.url }}" class="actor">
-                  <img src="{{ actor.image_url }}" alt="{{ actor.title }}" class="actor-image" width="80" height="80">
+              <li class="actor-links__item">
+                <a href="{{ actor.url }}">
+                  <img src="{{ actor.image_url }}" alt="{{ actor.title }}" class="actor-image">
                   <br>
                   {{ actor.title }}
                 </a>
+              </li>
               {% endfor %}
-            </div>
+            </ul>
             {{ content }}
           </section>
           <footer class="article-footer">

--- a/actors/index.html
+++ b/actors/index.html
@@ -19,9 +19,9 @@ description: soussuneの出演者一覧
             </div>
           </header>
 
-          <section class="card-body markdown">
+          <section class="card-body markdown actors">
 
-            <div class="list-group-element-images">
+            <ul class="actor-links">
 
 {% assign post_actor_ids =  site.posts | map: 'actor_ids' | join: ','  | split: ',' | sort %}
 {% assign actor_and_count = '' | split: '.' %}
@@ -41,14 +41,16 @@ description: soussuneの出演者一覧
 
               {% for item in sorted_actor_and_count reversed %}
                 {% assign actor = item.actor %}
-                <a href="{{ actor.url }}" class="actor">
+              <li class="actor-links__item">
+                <a href="{{ actor.url }}">
                   <img src="{{ actor.image_url | prepend:site.baseurl }}" alt="{{ actor.title }}" class="actor-image" width="80" height="80">
                   <br>
                   {{ actor.title }}
                   ({{ item.count }})
                 </a>
+              </li>
               {% endfor %}
-            </div>
+            </ul>
 
           </section>
 

--- a/css/blocks/_actor.scss
+++ b/css/blocks/_actor.scss
@@ -1,20 +1,31 @@
-.actor {
-  display: inline-block;
-  margin-bottom: 1rem;
-  text-align: center;
+.actor-links {
+  padding: 0 !important;
+  margin: 0 -10px;
 
-  &,
-  &:active,
-  &:focus,
-  &:hover {
-    text-decoration: none !important;
-  }
+  &__item {
+    display: inline-block;
+    margin-bottom: 1rem;
+    text-align: center;
 
-  & + & {
-    margin-left: 1rem;
-  }
+    min-width: 100px;
 
-  &-image {
-    border-radius: 50%;
+    .actors & {
+      font-size: 14px;
+    }
+
+    & a{
+      &,
+      &:active,
+      &:focus,
+      &:hover {
+        text-decoration: none !important;
+      }
+    }
   }
+}
+
+.actor-image {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
 }


### PR DESCRIPTION
issue #11 

# やったこと
- リストアイテム間にmarginで余白設定していたところを、min-widthで固定幅化。
- 画像幅(80px)に対してリストアイテム幅(100px)の方が大きいので、親コンテナの左右端に合うようにリスト左右にネガティブマージン設定
- actor一覧ページは登場回数も含まれるのでフォントサイズを小さめに設定（出演回数表示はなんか通知件数的なバッジ化してもいいかも）
- div要素をul, liに変更

# in Actors list
## Before
<img width="1004" alt="2017-08-03 10 53 17" src="https://user-images.githubusercontent.com/1443118/28902483-0fdb1596-783a-11e7-8696-9f05fa7910d3.png">

## After
<img width="991" alt="2017-08-03 12 02 26" src="https://user-images.githubusercontent.com/1443118/28904125-bfb46c84-7843-11e7-9e97-752dc1e3fa29.png">


# in Article

## Before
<img width="368" alt="2017-08-03 10 53 50" src="https://user-images.githubusercontent.com/1443118/28902482-0fbc2820-783a-11e7-8109-c907a8c48c57.png">

## After
<img width="361" alt="2017-08-03 11 59 12" src="https://user-images.githubusercontent.com/1443118/28904070-63362ae2-7843-11e7-840c-342fa6ecb356.png">
