### PR TITLE
Remove unnecessary elements from letter form

### DIFF
--- a/_includes/letter.html
+++ b/_includes/letter.html
@@ -9,5 +9,3 @@
   <button id="form-submit" type="submit">SUBMIT</button>
 </form>
 <p id="input-feedback"></p>
-<iframe src="#" id="no-target" name="no-target" style="visibility:hidden"></iframe>
-<a href="https://docs.google.com/forms/d/13n0z30Q1nM_JCndajM6piDvmBgQ4zW4DNm5m98ODL88/formResponse?entry.286431956={{%20page.title%}}">


### PR DESCRIPTION
<img width="1012" alt="2017-08-14 14 31 35" src="https://user-images.githubusercontent.com/1443118/29259424-dbdfbf04-80fd-11e7-8b36-d96ffcf46c29.png">

## 不具合
- 無駄に自身のページをiframeでincludeしている
- 各epを開くとこのフッタ部にスクロールしてしまう
- 妙な余白ができてる
- フッタのナビゲーション表示がずれてる

## 対応
- iframeとa要素を削除

## メモ

- 削ったaタグは、podcastのフィードからgoogle formsを開くためのもの
- フィードの方にだけ追加するようにする