### PR TITLE
Set link targets in show notes to _blank

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -54,7 +54,9 @@
               </li>
               {% endfor %}
             </ul>
-            {{ content }}
+            <div class="shownotes">
+              {{ content }}
+            </div>
           </section>
           <section class="card-body markdown letter">
             {% include letter.html post=page %}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -79,5 +79,6 @@
       </div>
     </main>
     {% include footer.html %}
+    <script src="/js/shownotes.js"></script>
   </body>
 </html>

--- a/js/shownotes.js
+++ b/js/shownotes.js
@@ -1,0 +1,3 @@
+jQuery(function($) {
+  $('.shownotes a, .letter a').attr('target', '_blank')
+})


### PR DESCRIPTION
#33 

## 課題
記事内の外部リンクを新規タブで開くようにする

## やったこと
- 各episodeのshow notes内のanchorに対し、jsでblank targetを付加。選択用に要素にclass追加。
- おたよりフォームのリンクも同様
- 出演者リンクや前後記事へのナビゲーション、ヘッダ・フッタについては内部リンクのためターゲット設定はしない