### PR TITLE
Add bold styling to markdown headers

### DIFF
--- a/css/blocks/_markdown.scss
+++ b/css/blocks/_markdown.scss
@@ -135,6 +135,7 @@
     line-height: 1.25;
     margin-bottom: 16px;
     margin-top: 24px;
+    font-weight: 700;
   }
 
   h1,


### PR DESCRIPTION
ShowNotes内の見出しが分かりづらいので、とりあえず安直に太字にして視認性を高くして対応したいと思います

## Before
![soussune com-episode-24](https://user-images.githubusercontent.com/1443118/29877592-056bc9e6-8ddb-11e7-9a79-2596b3c85de7.png)

## After
![deploy-preview-41--soussune netlify com-episode-24-](https://user-images.githubusercontent.com/1443118/29877608-0d58de64-8ddb-11e7-95f6-0791f7cce7bc.png)