### PR TITLE
Support iPhone X

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,10 +1,10 @@
 <head>
   <meta charset="utf-8">
   <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }} - {{ site.subtitle}}</title>
-  <meta name="viewport" content="width=device-width">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="{% include page_or_site_description.inc page=page %}" />
   <meta name="apple-itunes-app" content="app-id={{ site.apple_itunes_app_id }}">
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta property="og:title" content="{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }} - {{ site.subtitle}}" />
   <meta property="og:description" content="{% include page_or_site_description.inc page=page %}" />
   <meta property="og:image" content="{{ site.url }}/images/ogp-artwork.jpg" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="{% include page_or_site_description.inc page=page %}" />
   <meta name="apple-itunes-app" content="app-id={{ site.apple_itunes_app_id }}">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta property="og:title" content="{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }} - {{ site.subtitle}}" />
   <meta property="og:description" content="{% include page_or_site_description.inc page=page %}" />
   <meta property="og:image" content="{{ site.url }}/images/ogp-artwork.jpg" />

--- a/css/blocks/_footer.scss
+++ b/css/blocks/_footer.scss
@@ -2,6 +2,8 @@
   color: #BBBBBB;
   background: #222222;
   font-size: 0.9rem;
+  padding-right: constant(safe-area-inset-right);
+  padding-left:  constant(safe-area-inset-left);
   padding-bottom: 64px;
   padding-top: 64px;
 

--- a/css/blocks/_header.scss
+++ b/css/blocks/_header.scss
@@ -2,7 +2,7 @@
   background-image: url(../images/header.jpg);
   background-size: cover;
   background-position: center;
-
+  
   &-description {
     color: $color-text-light-secondary;
     font-size: 0.9rem;
@@ -27,6 +27,8 @@
   &-overlay {
     background-color: rgba(0, 0, 0, 0.3);
     height: 100%;
+    padding-right: constant(safe-area-inset-right);
+    padding-left:  constant(safe-area-inset-left);
     padding-bottom: 96px;
     padding-top: 96px;
   }

--- a/css/blocks/_main.scss
+++ b/css/blocks/_main.scss
@@ -1,5 +1,7 @@
 .main {
   background-color: #f9f9f9;
+  padding-right: constant(safe-area-inset-right);
+  padding-left:  constant(safe-area-inset-left);
   padding-bottom: 48px;
   padding-top: 48px;
 }


### PR DESCRIPTION
iOS 11 Safariにて、表示を確認しました。
縦向きに関しては、すべてのWebサイトにおいて空白はないようです。

**縦向き**
<img width="545" alt="screen shot 2017-10-15 at 16 51 52" src="https://user-images.githubusercontent.com/2557813/31582838-54ec15f4-b1c9-11e7-93af-a7f80a9e5f6c.png">

横向きに関しては、以下のように空白がでる仕様のようです。

**横向き before**
<img width="964" alt="screen shot 2017-10-15 at 16 52 35" src="https://user-images.githubusercontent.com/2557813/31582847-9388541c-b1c9-11e7-88b3-d89ca50c254b.png">

**横向き after**
<img width="964" alt="screen shot 2017-10-15 at 16 52 29" src="https://user-images.githubusercontent.com/2557813/31582846-8c3db5c6-b1c9-11e7-82d4-c865cec02088.png">
