### PR TITLE
Update style for iPhone X

### DIFF
--- a/css/blocks/_base.scss
+++ b/css/blocks/_base.scss
@@ -19,4 +19,9 @@ body {
   font-size: 17px;
   line-height: 1.7;
   word-wrap: break-word;
+
+  > *, :not(.header), .header-overlay {
+    padding-right: constant(safe-area-inset-right);
+    padding-left:  constant(safe-area-inset-left);
+  }
 }

--- a/css/blocks/_base.scss
+++ b/css/blocks/_base.scss
@@ -20,8 +20,8 @@ body {
   line-height: 1.7;
   word-wrap: break-word;
 
-  > *, :not(.header), .header-overlay {
+  .main, .footer, .header-overlay {
     padding-right: constant(safe-area-inset-right);
     padding-left:  constant(safe-area-inset-left);
-  }
+  }  
 }

--- a/css/blocks/_footer.scss
+++ b/css/blocks/_footer.scss
@@ -2,8 +2,6 @@
   color: #BBBBBB;
   background: #222222;
   font-size: 0.9rem;
-  padding-right: constant(safe-area-inset-right);
-  padding-left:  constant(safe-area-inset-left);
   padding-bottom: 64px;
   padding-top: 64px;
 

--- a/css/blocks/_header.scss
+++ b/css/blocks/_header.scss
@@ -27,8 +27,6 @@
   &-overlay {
     background-color: rgba(0, 0, 0, 0.3);
     height: 100%;
-    padding-right: constant(safe-area-inset-right);
-    padding-left:  constant(safe-area-inset-left);
     padding-bottom: 96px;
     padding-top: 96px;
   }

--- a/css/blocks/_main.scss
+++ b/css/blocks/_main.scss
@@ -1,7 +1,5 @@
 .main {
   background-color: #f9f9f9;
-  padding-right: constant(safe-area-inset-right);
-  padding-left:  constant(safe-area-inset-left);
   padding-bottom: 48px;
   padding-top: 48px;
 }

--- a/css/blocks/_reset.scss
+++ b/css/blocks/_reset.scss
@@ -12,7 +12,12 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
   display: block; }
 
 body {
-  line-height: 1; }
+  line-height: 1;
+  > * {
+    padding-right: constant(safe-area-inset-right);
+    padding-left:  constant(safe-area-inset-left);
+  }
+}
 
 ol, ul {
   list-style: none; }

--- a/css/blocks/_reset.scss
+++ b/css/blocks/_reset.scss
@@ -13,7 +13,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
 
 body {
   line-height: 1;
-  > * {
+  > *, .header-overlay {
     padding-right: constant(safe-area-inset-right);
     padding-left:  constant(safe-area-inset-left);
   }

--- a/css/blocks/_reset.scss
+++ b/css/blocks/_reset.scss
@@ -12,12 +12,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
   display: block; }
 
 body {
-  line-height: 1;
-  > *, .header-overlay {
-    padding-right: constant(safe-area-inset-right);
-    padding-left:  constant(safe-area-inset-left);
-  }
-}
+  line-height: 1; }
 
 ol, ul {
   list-style: none; }


### PR DESCRIPTION
body直下で指定しろとご指摘されたけど、
オーバレイの記述とか直下じゃないのでheaderがこうなっているよと説明するためのブランチ

冗長なところだけ解消してbase.cssに移動

<img width="964" alt="screen shot 2017-10-15 at 17 57 53" src="https://user-images.githubusercontent.com/2557813/31583270-1e788034-b1d3-11e7-9e99-835d22502777.png">
